### PR TITLE
更新 json_annotation（至 ^4.0.1） 和 json_serializable（至 ^4.1.0）

### DIFF
--- a/shanyan/pubspec.yaml
+++ b/shanyan/pubspec.yaml
@@ -10,13 +10,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  json_annotation: ^3.0.1
+  json_annotation: ^4.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^1.2.2
-  json_serializable: ^3.2.5
+  json_serializable: ^4.1.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
最新的 json_serializable （4.1.0）限制了 json_annotation 的版本（json_annotation: '>=4.0.1 <4.1.0'），具体[源码](https://github.com/google/json_serializable.dart/blob/818c48f82893764c7d6bee7f884a63d301310713/json_serializable/pubspec.yaml#L18)